### PR TITLE
feat: add js script to get translation strings hashes from transifex

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,13 @@
         "es6": true,
         "node": true
     },
-    "extends": "eslint:recommended",
+    "extends": "airbnb",
+    "parserOptions": {
+        "ecmaVersion": 8,
+        "ecmaFeatures": {
+          "jsx": true
+        }
+    },
     "rules": {
         "linebreak-style": [
             "error",
@@ -16,6 +22,15 @@
         "semi": [
             "error",
             "always"
+        ],
+        "keyword-spacing": [
+            "error", { 
+                "before": true, "after": true 
+            }
+        ],
+        "max-len": [
+            "error",
+            120
         ]
     }
 }

--- a/bash_scripts/get_hashed_strings_v3.sh
+++ b/bash_scripts/get_hashed_strings_v3.sh
@@ -1,0 +1,8 @@
+# Wrapper bash script that calls src/get_hashed_strings.js script
+#!/bin/bash
+
+# TRANSIFEX_RESOURCE = environment variable containing the name of resource on Transifex whose
+# string hashes should be fetched. This will be defined and exported in respective MFE's Makefile
+#
+# TRANSIFEX_AUTH_TOKEN = environment variable containing Transifex Auth token.
+node src/get_hashed_strings.js --resource=$TRANSIFEX_RESOURCE --token=$TRANSIFEX_AUTH_TOKEN

--- a/package.json
+++ b/package.json
@@ -29,6 +29,15 @@
   },
   "homepage": "https://github.com/efischer19/reactifex#readme",
   "devDependencies": {
-    "eslint": "^4.18.2"
+    "eslint": "^7.32.0",
+    "eslint-config-airbnb": "^18.2.1",
+    "eslint-plugin-import": "^2.24.2",
+    "eslint-plugin-jsx-a11y": "^6.4.1",
+    "eslint-plugin-react": "^7.25.1",
+    "eslint-plugin-react-hooks": "^1.7.0"
+  },
+  "dependencies": {
+    "axios": "^0.21.1",
+    "yargs": "^17.1.1"
   }
 }

--- a/src/get_hashed_strings.js
+++ b/src/get_hashed_strings.js
@@ -1,0 +1,96 @@
+/*
+Script to get the translation string hashes for a given resource from Transifex.
+
+Sample usage:
+  * node src/get_hashed_strings.js --resource=<resource> --token=<transifex_token>
+
+When running on local, override outputJsonDirectory value by adding --outputJsonDirectory=bash_scripts in the command.
+The default value of output directory is ./node_modules/reactifex/bash_scripts, which is the path where MFEs
+will create the json file when running push translations. However, when testing reactifex on local devstack,
+the default path will not be found as reactifex itself won't be installed in reactifex.
+*/
+
+const axios = require("axios");
+const fs = require("fs");
+const yargs = require("yargs");
+
+// Configure command line arguments with yargs
+yargs.option(
+  "organization", {
+    alias: ["o", "org"],
+    default: "open-edx",
+    description: "Organization associated with Transifex account",
+  },
+).option(
+  "project", {
+    alias: ["p", "proj"],
+    default: "edx-platform",
+    description: "Project within a Transifex organization",
+  },
+)
+  .option(
+    "outputJsonDirectory", {
+      description: "Directory where the hashmap json file will be created",
+      default: "./node_modules/reactifex/bash_scripts",
+    },
+  )
+  .option(
+    "resource", {
+      alias: ["r", "res"],
+      demandOption: true,
+      description: "Resource within a Transifex project whose translation strings are to be fetched",
+    },
+  )
+  .option(
+    "token", {
+      description: "Bearer token required for Authentication when making API calls to Transifex",
+      demandOption: true,
+    },
+  );
+
+const API_BASE_URL = "https://rest.api.transifex.com/resource_strings";
+const OUTPUT_JSON_PATH = `${yargs.argv.outputJsonDirectory}/hashmap.json`;
+
+/*
+Recursively get the translation string hashes for a given resource.
+*/
+async function getStringHashes(url, authToken) {
+  let data = [];
+  try {
+    const response = await axios.get(url, { headers: { Authorization: `Bearer ${authToken}` } });
+
+    data = [...response.data.data];
+    const nextLink = response.data.links.next;
+
+    if (nextLink !== undefined && nextLink !== null) {
+      const nextPageData = await getStringHashes(nextLink, authToken);
+      data = data.concat(nextPageData);
+    }
+  } catch (err) {
+    process.stderr.write(`Error during transifex string hash fetch\nMessage: ${err.message}\n`);
+  }
+  return data;
+}
+
+async function main() {
+  const args = yargs.argv;
+  const apiUrl = `${API_BASE_URL}?filter[resource]=o:${args.org}:p:${args.project}:r:${args.resource}`;
+
+  process.stdout.write(`Fetching translation string hashes for url ${apiUrl}\n`);
+  const response = await getStringHashes(apiUrl, args.token);
+  return response.map((stringHash) => stringHash.attributes);
+}
+
+(async function () {
+  const output = await main();
+  if (output.length !== 0) {
+    try {
+      fs.writeFileSync(OUTPUT_JSON_PATH, JSON.stringify(output, null, 2));
+      process.stdout.write(`Hashed strings information written to ${OUTPUT_JSON_PATH}\n`);
+    } catch (error) {
+      process.stderr.write(`Output write to directory ${OUTPUT_JSON_PATH} failed with error ${error.message}\n`);
+    }
+  } else {
+    process.stdout.write("No data has been written to the output file\n");
+  }
+}());


### PR DESCRIPTION
### [PROD-2483](https://openedx.atlassian.net/browse/PROD-2483)

### Description

Adds JS script to get translation string hashes for a given resource using Transifex API v3. The difference between v2 and v3 api can be seen in [this internal document](https://openedx.atlassian.net/wiki/spaces/IM/pages/3139731467/edx+reactifex+Migrating+to+Transifex+API+v3). The old script that utilizes API v2 has been written as the bash script. With API v3, the bash script choice was not taken because:

- API v3 get translation string hash endpoint is now paginated. The paginated response does not return the number of pages and relies on the next attribute to decide if more data is present or not
- Along with the pagination, the API response structure has changed significantly. The data needs to be read from appropriate dict keys.
- API urls have also changed, particularly the way data is queried.


Although all of above actions could have been replicated in bash script, writing JS script and running it through node is better because the script is readable, easier to understand, provides better tools for manipulation of data, and utilizes programming language features(effective error handling). A wrapper bash script has been added that is just calling the JS script and masks some details in terms of command-line arguments.

**NOTE: The tests for the script have not been added yet. This repo will require configurations and updates which will be done in a follow-up PR.**