### PR TITLE
fix: Fix loop inconsistent behavior with async/await in put comments

### DIFF
--- a/src/put_comments.js
+++ b/src/put_comments.js
@@ -101,7 +101,7 @@ async function addInstructions(translationStringsData, args) {
   if (translationStringsData.length !== 0) {
     const resourceIdBaseString = `o:${args.org}:p:${args.project}:r:${args.resource}`;
 
-    translationStringsData.forEach(async (value) => {
+    for (let counter = 0; counter < translationStringsData.length; counter += 1) {
       /*
       Convert string <hash>|<instructions> into list
       Get hash from the first element
@@ -109,17 +109,20 @@ async function addInstructions(translationStringsData, args) {
       so that if the instruction string itself contained |, the splitted data length will
       be more than 2 and there might be chance of incomplete instruction being added to Transifex.
       */
+      const value = translationStringsData[counter];
       const valueList = value.split("|");
       const hash = valueList[0];
       const instructions = valueList.slice(1).join("|");
       const stringId = `${resourceIdBaseString}:s:${hash}`;
       process.stdout.write(`Hash: ${stringId}, Instructions: ${instructions}\n`);
+      // eslint-disable-next-line no-await-in-loop
       await addStringInstructions(stringId, instructions, args.token);
-    });
+      process.stdout.write(`Instruction addition for Hash ${stringId} completed\n`);
+    }
   }
 }
 
-async function main() {
+(async function () {
   const args = yargs.argv;
   const inputFilePath = `${args.inputFileDirectory}/hashed_data.txt`;
   let inputData = [];
@@ -130,8 +133,4 @@ async function main() {
     process.stderr.write(`Encountered an error while attempting to open ${inputFilePath}\nError:${error.message}\n`);
   }
   await addInstructions(inputData, args);
-}
-
-(async function () {
-  await main();
 }());


### PR DESCRIPTION
### [PROD-2526](https://openedx.atlassian.net/browse/PROD-2526)

### Description

- Use traditional for loop instead of forEach to fix async/await behavior. The inconsistency popped up when push translation was run for support tools MFE(incorrect logs order). This can result in behavior where the sync execution will stop but async processes will still be in progress. Traditional for loop will make sure api calls happen sequentially and finish with the overall sync execution
- Remove extra async/await chain by moving main logic in the caller function

### References

- https://masteringjs.io/tutorials/fundamentals/array-iterate
- https://www.coreycleary.me/why-does-async-await-in-a-foreach-not-actually-await
- https://advancedweb.hu/how-to-use-async-functions-with-array-foreach-in-javascript/